### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#costo
+# costo
 [costco](http://harthur.github.com/costco) is a small UI for bulk editing CouchDB documents.
 
-#install
+# install
 costco is a [couchapp](http://couchapp.org), you can push it to any db:
 
 	git clone http://github.com/harthur/costco.git
 	cd costco
 	couchapp push . http://hostname:5984/mydatabase
 
-#usage
+# usage
 costco takes a map function and executes it on all the docs in the database. The map function should return the new doc that you'd like to replace the old one, or `null` if it should be deleted. Returning `undefined` does nothing to that doc.
 
 An example map function that increments a field in all the docs and deletes some docs based on another field:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
